### PR TITLE
Remove hacky transition awaiting behavior

### DIFF
--- a/demo/demo.scss
+++ b/demo/demo.scss
@@ -186,10 +186,10 @@ input[type='number'] {
 @keyframes kOverlayAnimation {
   0% {
     transform-origin: 0% 0%;
-    transform: rotateZ(180deg);
+    opacity: 0;
   }
   100% {
     transform-origin: 0% 0%;
-    transform: rotateZ(0deg);
+    opacity: 1;
   }
 }

--- a/demo/demo.scss
+++ b/demo/demo.scss
@@ -186,10 +186,10 @@ input[type='number'] {
 @keyframes kOverlayAnimation {
   0% {
     transform-origin: 0% 0%;
-    opacity: 0;
+    transform: rotateZ(180deg);
   }
   100% {
     transform-origin: 0% 0%;
-    opacity: 1;
+    transform: rotateZ(0deg);
   }
 }

--- a/demo/demos/jsTransition/index.tsx
+++ b/demo/demos/jsTransition/index.tsx
@@ -1,6 +1,5 @@
 import { defineComponent } from 'vue';
 
-import { Side } from '@floating-ui/vue';
 import { defineDemo, html } from '../../helpers';
 import { Wowerlay, type WowerlayTransitionFn } from '../../../src/lib';
 import useDemoState from '../../helpers/useDemoState';
@@ -8,11 +7,9 @@ import useDemoState from '../../helpers/useDemoState';
 const Component = defineComponent({
   name: 'JsTransition',
   setup: () => {
-    const handleTransition: WowerlayTransitionFn = (type, { popover }, done) => {
-      const placement = popover.getAttribute('data-popover-placement')!.split('-')[0] as Side;
-
+    const handleTransition: WowerlayTransitionFn = (type, { popover, side }, done) => {
       const from = {
-        transform: `translateY(${placement === 'top' ? '10px' : '-10px'})`,
+        transform: `translateY(${side === 'top' ? '10px' : '-10px'})`,
         opacity: 0,
       };
 
@@ -84,11 +81,15 @@ export default defineDemo({
     <script setup>
       import { ref } from 'vue';
 
-      const handleTransition = (type, el, done) => {
+      const handleTransition = (type, { popover, side, background }, done) => {
+        if (background) {
+          doBackgroundAnimation(background);
+        }
+
         if (type === 'enter') {
-          doAnimation(el).onFinish(done);
+          doAnimation(popover).onFinish(done);
         } else {
-          doAnimation(el).onFinish(done);
+          doAnimation(popover).onFinish(done);
         }
       };
 

--- a/demo/demos/jsTransition/index.tsx
+++ b/demo/demos/jsTransition/index.tsx
@@ -8,8 +8,8 @@ import useDemoState from '../../helpers/useDemoState';
 const Component = defineComponent({
   name: 'JsTransition',
   setup: () => {
-    const handleTransition: WowerlayTransitionFn = (type, element, done) => {
-      const placement = element.getAttribute('data-popover-placement')!.split('-')[0] as Side;
+    const handleTransition: WowerlayTransitionFn = (type, { popover }, done) => {
+      const placement = popover.getAttribute('data-popover-placement')!.split('-')[0] as Side;
 
       const from = {
         transform: `translateY(${placement === 'top' ? '10px' : '-10px'})`,
@@ -21,7 +21,7 @@ const Component = defineComponent({
         opacity: 1,
       };
 
-      const animation = element.animate(type === 'enter' ? [from, to] : [to, from], {
+      const animation = popover.animate(type === 'enter' ? [from, to] : [to, from], {
         duration: 200,
         easing: 'ease',
       });

--- a/demo/demos/withTransition/index.tsx
+++ b/demo/demos/withTransition/index.tsx
@@ -54,6 +54,18 @@ export default defineDemo({
         </Wowerlay>
       </button>
     </template>
+
+    <!--
+      you need to explicitly select standalone popover or popover inside background.
+      If you change position of popover in css transition (e.g. transform: translateX(100%)) it will break positioning of popover.
+      If you need to change position of popover while transitioning, use JS transition instead.
+    -->
+    <style>
+      .wowerlay-background.transition-name-enter-active wowerlay[data-popover-placement="right"],
+      .wowerlay[data-popover-placement="right"].transition-name-enter-active {
+        animation: myAnimation .3s;
+      }
+    </style>
   `,
   script: html`
     <script setup>

--- a/src/components/Wowerlay.constants.ts
+++ b/src/components/Wowerlay.constants.ts
@@ -8,7 +8,7 @@ import {
 
 export type WowerlayTransitionFn = (
   type: 'enter' | 'leave',
-  elements: { background: HTMLElement | null; popover: HTMLElement },
+  params: { background: HTMLElement | null; popover: HTMLElement; side: Side },
   done: () => void,
 ) => void;
 

--- a/src/components/Wowerlay.constants.ts
+++ b/src/components/Wowerlay.constants.ts
@@ -8,7 +8,12 @@ import {
 
 export type WowerlayTransitionFn = (
   type: 'enter' | 'leave',
-  params: { background: HTMLElement | null; popover: HTMLElement; side: Side },
+  params: {
+    background: HTMLElement | null;
+    popover: HTMLElement;
+    side: Side;
+    placement: AlignedPlacement | Side;
+  },
   done: () => void,
 ) => void;
 

--- a/src/components/Wowerlay.constants.ts
+++ b/src/components/Wowerlay.constants.ts
@@ -8,7 +8,7 @@ import {
 
 export type WowerlayTransitionFn = (
   type: 'enter' | 'leave',
-  el: HTMLElement,
+  elements: { background: HTMLElement | null; popover: HTMLElement },
   done: () => void,
 ) => void;
 
@@ -25,6 +25,7 @@ export interface WowerlayProps {
   transition: string | WowerlayTransitionFn;
   syncSize: boolean;
   arrowPadding: number;
+  middlewares: Middleware[];
   backgroundAttrs: HTMLAttributes & {
     ref?: ((element: HTMLDivElement | null) => void) | Ref<HTMLElement | null | undefined>;
     key?: undefined | null;
@@ -78,11 +79,11 @@ export const Props = {
     type: [String, Function] as PropType<WowerlayProps['transition']>,
   },
   visible: {
-    type: Boolean,
+    type: Boolean as PropType<WowerlayProps['visible']>,
     required: true,
   },
   middlewares: {
-    type: Array as PropType<Middleware[]>,
+    type: Array as PropType<WowerlayProps['middlewares']>,
     default: () => [],
   },
   arrowPadding: {

--- a/src/components/Wowerlay.tsx
+++ b/src/components/Wowerlay.tsx
@@ -225,9 +225,10 @@ export const Wowerlay = defineComponent({
         const popover = (
           background ? background.getElementsByClassName('wowerlay')[0] : el
         ) as HTMLElement;
+        const side = popover.getAttribute('data-popover-placement')!.split('-')[0] as Side;
 
         if (typeof props.transition === 'function')
-          props.transition(type, { background, popover }, done);
+          props.transition(type, { background, popover, side }, done);
       });
     };
 

--- a/src/components/Wowerlay.tsx
+++ b/src/components/Wowerlay.tsx
@@ -1,11 +1,12 @@
 import {
+  Ref,
+  Slots,
   Teleport,
   Transition,
   computed,
   defineComponent,
   onBeforeUnmount,
   onMounted,
-  ref,
   shallowRef,
   toRef,
   watch,
@@ -22,9 +23,10 @@ import {
   type Side,
   AlignedPlacement,
   limitShift,
+  MiddlewareData,
 } from '@floating-ui/vue';
 
-import { Props } from './Wowerlay.constants';
+import { Props, WowerlayProps } from './Wowerlay.constants';
 import { NOOP, isElement, isValidTarget } from '../utils';
 import { attrs, syncSize } from './Wowerlay.middlewares';
 import { useSlotWithRef } from '../composables';
@@ -36,6 +38,66 @@ export interface WowerlayTemplateRef {
 export interface ArrowProps {
   side: Side;
   placement: AlignedPlacement;
+}
+
+function combineMiddlewares(
+  props: Readonly<WowerlayProps>,
+  slots: Slots,
+  arrowElement: Ref<HTMLElement | null>,
+) {
+  const middlewares = [attrs()] as Middleware[];
+
+  if (typeof props.gap === 'number' && props.gap !== 0) middlewares.push(offset(props.gap));
+  if (!props.noFlip) middlewares.push(flip());
+  if (props.syncSize) middlewares.push(syncSize());
+
+  middlewares.push(
+    shift({
+      crossAxis: true,
+      limiter: props.canLeaveViewport ? limitShift() : undefined,
+    }),
+  );
+
+  if ('arrow' in slots)
+    middlewares.push(arrow({ element: arrowElement.value, padding: props.arrowPadding }));
+
+  return middlewares.concat(props.middlewares || []);
+}
+
+function creteArrowStyles(
+  arrowProps: Readonly<Ref<ArrowProps>>,
+  middlewareData: Readonly<Ref<MiddlewareData>>,
+) {
+  const { side } = arrowProps.value;
+
+  let left = '';
+  let top = '';
+  let bottom = '';
+  let right = '';
+
+  const { x = 0, y = 0 } = middlewareData.value?.arrow || {};
+
+  if (side === 'left') {
+    top = `${y}px`;
+    left = '100%';
+  } else if (side === 'right') {
+    top = `${y}px`;
+    right = '100%';
+  } else if (side === 'top') {
+    top = '100%';
+    left = `${x}px`;
+  } else if (side === 'bottom') {
+    bottom = '100%';
+    left = `${x}px`;
+  }
+
+  return {
+    position: 'absolute',
+    left,
+    top,
+    right,
+    bottom,
+  };
 }
 
 export const Wowerlay = defineComponent({
@@ -78,25 +140,9 @@ export const Wowerlay = defineComponent({
             elementResize: true,
           });
         },
-        middleware: computed<Middleware[]>(() => {
-          const middlewares = [attrs()] as Middleware[];
-
-          if (typeof props.gap === 'number' && props.gap !== 0) middlewares.push(offset(props.gap));
-          if (!props.noFlip) middlewares.push(flip());
-          if (props.syncSize) middlewares.push(syncSize());
-
-          middlewares.push(
-            shift({
-              crossAxis: true,
-              limiter: props.canLeaveViewport ? limitShift() : undefined,
-            }),
-          );
-
-          if ('arrow' in slots)
-            middlewares.push(arrow({ element: arrowElement.value, padding: props.arrowPadding }));
-
-          return middlewares.concat(props.middlewares || []);
-        }),
+        middleware: computed<Middleware[]>(() =>
+          combineMiddlewares(props as Readonly<WowerlayProps>, slots, arrowElement),
+        ),
       },
     );
 
@@ -109,38 +155,7 @@ export const Wowerlay = defineComponent({
       } as ArrowProps;
     });
 
-    const arrowStyles = computed(() => {
-      const { side } = arrowProps.value;
-
-      let left = '';
-      let top = '';
-      let bottom = '';
-      let right = '';
-
-      const { x = 0, y = 0 } = middlewareData.value?.arrow || {};
-
-      if (side === 'left') {
-        top = `${y}px`;
-        left = '100%';
-      } else if (side === 'right') {
-        top = `${y}px`;
-        right = '100%';
-      } else if (side === 'top') {
-        top = '100%';
-        left = `${x}px`;
-      } else if (side === 'bottom') {
-        bottom = '100%';
-        left = `${x}px`;
-      }
-
-      return {
-        position: 'absolute',
-        left,
-        top,
-        right,
-        bottom,
-      };
-    });
+    const arrowStyles = computed(() => creteArrowStyles(arrowProps, middlewareData));
 
     watchEffect(() => {
       if (arrowElement.value) {
@@ -156,15 +171,11 @@ export const Wowerlay = defineComponent({
       emit('update:el', el);
     });
 
-    const popoverClosable = ref(false);
     const popoverVisible = computed(() => isValidTarget(props.target) && props.visible);
 
     const close = () => {
       if (!props.visible) return;
-
-      if (popoverClosable.value) {
-        emit('update:visible', false);
-      }
+      emit('update:visible', false);
     };
 
     onBeforeUnmount(close);
@@ -201,53 +212,30 @@ export const Wowerlay = defineComponent({
     };
 
     onMounted(() => {
-      window.addEventListener('click', handleWindowClick);
+      window.addEventListener('click', handleWindowClick, true);
     });
     onBeforeUnmount(() => {
-      window.removeEventListener('click', handleWindowClick);
+      window.removeEventListener('click', handleWindowClick, true);
     });
-
-    const backgroundVisible = ref(props.visible);
-
-    /** .
-     * If popover has a background we rely on popover's transition state to
-     * hide it with the background or not, otherwise leave transition will not be seen.
-     */
-    const handleContentTransitionEnd = () => {
-      backgroundVisible.value = false;
-    };
-
-    watch(
-      () => props.visible,
-      (state) => {
-        if (state) {
-          // Use setTimeout to prevent immediate popover closure caused by the same click event due to event bubbling.
-          // We listen to the window, so this ensures a single click doesn't simultaneously open and close the popover.
-          setTimeout(() => {
-            popoverClosable.value = true;
-          }, 0);
-
-          backgroundVisible.value = true;
-        } else {
-          popoverClosable.value = false;
-        }
-      },
-    );
 
     const handleTransition = (type: 'enter' | 'leave', el: Element, done: () => void) => {
       // We need to wait for FloatingUI to update the position before we can transition.
       requestAnimationFrame(() => {
-        if (typeof props.transition === 'function') props.transition(type, el as HTMLElement, done);
+        const background = el.matches('[data-wowerlay-background]') ? (el as HTMLElement) : null;
+        const popover = (
+          background ? background.getElementsByClassName('wowerlay')[0] : el
+        ) as HTMLElement;
+
+        if (typeof props.transition === 'function')
+          props.transition(type, { background, popover }, done);
       });
     };
 
     return {
-      handleContentTransitionEnd,
       floatingStyles,
       popoverVisible,
       backgroundEl,
       popoverEl,
-      backgroundVisible,
       middlewareData,
       arrowStyles,
       arrowProps,
@@ -258,7 +246,7 @@ export const Wowerlay = defineComponent({
   render() {
     const Tag = this.tag as /* for typechecking */ 'div';
 
-    const popover = this.popoverVisible ? (
+    const popover = (
       <Tag
         class="wowerlay"
         data-wowerlay-scope
@@ -269,12 +257,28 @@ export const Wowerlay = defineComponent({
         {this.renderArrow(this.arrowProps)}
         {this.$slots.default?.()}
       </Tag>
-    ) : null;
-
-    let wowerlayContentToRender = (
-      // onAfterLeave is called even if there is not animation
-      <Transition onAfterLeave={this.handleContentTransitionEnd}>{popover}</Transition>
     );
+
+    const backgroundAttrsClone = Object.assign(Object.create(null), this.backgroundAttrs);
+    delete backgroundAttrsClone.key;
+
+    let wowerlayContentToRender: JSX.Element | null = null;
+
+    if (this.popoverVisible) {
+      wowerlayContentToRender = this.noBackground ? (
+        popover
+      ) : (
+        <div
+          data-wowerlay-background
+          class="wowerlay-background"
+          role="dialog"
+          ref="backgroundEl"
+          {...backgroundAttrsClone}
+        >
+          {popover}
+        </div>
+      );
+    }
 
     if (typeof this.transition === 'function') {
       const handleEnter = (el: Element, done: () => void) =>
@@ -284,49 +288,18 @@ export const Wowerlay = defineComponent({
         this.handleTransition('leave', el, done);
 
       wowerlayContentToRender = (
-        <Transition
-          appear
-          onAppear={handleEnter}
-          onEnter={handleEnter}
-          onLeave={handleLeave}
-          onAfterLeave={this.handleContentTransitionEnd}
-        >
-          {popover}
+        <Transition appear onAppear={handleEnter} onEnter={handleEnter} onLeave={handleLeave}>
+          {wowerlayContentToRender}
         </Transition>
       );
     } else if (typeof this.transition === 'string') {
       wowerlayContentToRender = (
-        <Transition appear onAfterLeave={this.handleContentTransitionEnd} name={this.transition}>
-          {popover}
+        <Transition appear name={this.transition}>
+          {wowerlayContentToRender}
         </Transition>
       );
     }
 
-    const backgroundAttrsClone = Object.assign(Object.create(null), this.backgroundAttrs);
-    delete backgroundAttrsClone.key;
-
-    return (
-      <Teleport to="body">
-        {(() => {
-          if (this.noBackground) return wowerlayContentToRender;
-
-          if (this.backgroundVisible) {
-            return (
-              <div
-                data-wowerlay-background
-                class="wowerlay-background"
-                role="dialog"
-                ref="backgroundEl"
-                {...backgroundAttrsClone}
-              >
-                {wowerlayContentToRender}
-              </div>
-            );
-          }
-
-          return null;
-        })()}
-      </Teleport>
-    );
+    return <Teleport to="body">{wowerlayContentToRender}</Teleport>;
   },
 });

--- a/src/components/Wowerlay.tsx
+++ b/src/components/Wowerlay.tsx
@@ -225,10 +225,13 @@ export const Wowerlay = defineComponent({
         const popover = (
           background ? background.getElementsByClassName('wowerlay')[0] : el
         ) as HTMLElement;
-        const side = popover.getAttribute('data-popover-placement')!.split('-')[0] as Side;
+        const popoverPlacement = popover.getAttribute('data-popover-placement') as
+          | AlignedPlacement
+          | Side;
+        const side = popoverPlacement.split('-')[0] as Side;
 
         if (typeof props.transition === 'function')
-          props.transition(type, { background, popover, side }, done);
+          props.transition(type, { background, popover, side, placement: popoverPlacement }, done);
       });
     };
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - Currently Wowerlay is observing transition end event to hide popover but this is not a good way to handle this. For example, if user spams visible to true and false Wowerlay will not be able to show itself.
  
    What this PR introduces is, we put Transition element on top of background thus makes users have to explicitly select which element to add transition. Users can choose `background` or `popover` in JS transition phase but in css transition phase, users should use the correct transition name for background and content if `noBackground` is given.
  
    HandleWindowClick is now using `capture` and thanks to `capture` we now don't need to store a variable called `popoverClosable`, because bubbling does not exist anymore.

    Some functions are carried to global scope.